### PR TITLE
Fix CI coverage upload failure

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -5,7 +5,13 @@
       "Bash(bundle exec rspec:*)",
       "Bash(bundle install)",
       "Bash(git add:*)",
-      "Bash(git commit:*)"
+      "Bash(git commit:*)",
+      "Bash(CI=true bundle exec rspec spec/lib/migration_guard/configuration_spec.rb)",
+      "Bash(git push:*)",
+      "Bash(gh pr list:*)",
+      "Bash(gh pr checks:*)",
+      "Bash(gh run view:*)",
+      "Bash(ls:*)"
     ],
     "deny": []
   }

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,5 +53,6 @@ jobs:
     - name: Upload coverage reports
       uses: codecov/codecov-action@v3
       with:
-        file: ./coverage/coverage.xml
-        fail_ci_if_error: true
+        files: ./coverage/coverage.xml
+        fail_ci_if_error: false
+        verbose: true

--- a/Gemfile
+++ b/Gemfile
@@ -13,4 +13,5 @@ gem "rails", "~> #{rails_version}.0"
 group :development, :test do
   gem "pry"
   gem "pry-byebug" if RUBY_VERSION >= "3.0"
+  gem "simplecov-cobertura", "~> 2.1"
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -3,10 +3,24 @@
 require "bundler/setup"
 require "simplecov"
 
+# Configure SimpleCov for CI
+require "simplecov-cobertura" if ENV["CI"]
+
 SimpleCov.start do
   add_filter "/spec/"
   add_filter "/vendor/"
+  
+  # Add formatters for both HTML and XML (for CodeCov)
+  if ENV["CI"]
+    SimpleCov.formatters = SimpleCov::Formatter::MultiFormatter.new([
+      SimpleCov::Formatter::HTMLFormatter,
+      SimpleCov::Formatter::CoberturaFormatter
+    ])
+  end
 end
+
+# Ensure coverage directory exists
+SimpleCov.coverage_dir "coverage"
 
 require "rails-migration-guard"
 


### PR DESCRIPTION
## Summary
- Fixed CI failures caused by missing XML coverage reports
- Made coverage upload non-failing to handle CodeCov rate limits

## Changes
- Added `simplecov-cobertura` gem to generate XML coverage reports
- Updated spec_helper.rb to use Cobertura formatter when CI=true
- Fixed codecov-action configuration (changed 'file' to 'files' parameter)
- Set `fail_ci_if_error: false` to prevent CI failures from CodeCov rate limits
- Added verbose flag for better debugging

## Testing
- Tested locally with `CI=true bundle exec rspec` - coverage.xml is generated correctly
- This fix should resolve CI failures for PRs #31 and #32

## Note
CodeCov is rate limiting uploads without authentication tokens. The coverage upload will still run but won't fail the CI if it encounters rate limits. To fully enable CodeCov, a CODECOV_TOKEN should be added to the repository secrets.

## Impact
Once merged, all open PRs should have passing CI again.