### PR TITLE
feat: add support for multiple remote branches

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,6 +147,12 @@ MigrationGuard.configure do |config|
 
   # Main branch names to check against
   config.main_branch_names = %w[main master trunk]
+  
+  # Target branches to compare migrations against (optional)
+  # When set, migrations will be compared against all specified branches
+  # instead of just the main branch. Useful for teams with multiple
+  # long-lived branches (e.g., develop, staging, production)
+  # config.target_branches = %w[main develop staging]
 end
 ```
 
@@ -183,14 +189,12 @@ end
 
 ## Troubleshooting
 
-### "Migration not found" errors
-This usually means you have orphaned migrations. Run `rails db:migration:status` to identify them.
+For comprehensive troubleshooting information, see our [Troubleshooting Guide](TROUBLESHOOTING.md).
 
-### Git integration not working
-Ensure you're in a git repository and have git installed. The gem gracefully degrades without git.
-
-### Performance concerns
-The gem has minimal overhead and only runs in development/staging. Set `git_integration_level: :off` to disable git operations.
+Common issues:
+- **"Migration not found" errors**: Usually means you have orphaned migrations. Run `rails db:migration:status` to identify them.
+- **Git integration not working**: Ensure you're in a git repository and have git installed.
+- **Performance concerns**: The gem has minimal overhead. Set `git_integration_level: :off` to disable git operations if needed.
 
 ## Development
 

--- a/TROUBLESHOOTING.md
+++ b/TROUBLESHOOTING.md
@@ -1,0 +1,307 @@
+# Troubleshooting Guide for Rails Migration Guard
+
+This guide helps you resolve common issues when using the rails-migration-guard gem.
+
+## Table of Contents
+
+1. [Git Command Not Found](#git-command-not-found)
+2. [Permission Issues](#permission-issues)
+3. [Database Connection Errors](#database-connection-errors)
+4. [Migration Version Conflicts](#migration-version-conflicts)
+5. [Performance Issues](#performance-issues)
+6. [Rails Version Compatibility](#rails-version-compatibility)
+7. [Common Error Messages](#common-error-messages)
+
+## Git Command Not Found
+
+### Problem
+You see errors like:
+```
+MigrationGuard::GitError: Git command not found
+```
+
+### Solution
+1. **Verify Git is installed:**
+   ```bash
+   which git
+   # Should output something like: /usr/bin/git
+   ```
+
+2. **Install Git if missing:**
+   - macOS: `brew install git`
+   - Ubuntu/Debian: `sudo apt-get install git`
+   - CentOS/RHEL: `sudo yum install git`
+
+3. **Check PATH environment variable:**
+   ```bash
+   echo $PATH
+   # Ensure it includes the directory containing git
+   ```
+
+4. **For deployment environments:**
+   - Ensure Git is available in your Docker image or deployment environment
+   - Consider disabling MigrationGuard in production if Git isn't available:
+   ```ruby
+   # config/initializers/migration_guard.rb
+   MigrationGuard.configure do |config|
+     config.enabled_environments = [:development, :staging]
+     # Explicitly exclude production
+   end
+   ```
+
+## Permission Issues
+
+### Problem
+Errors accessing migration files or the migration_guard_records table:
+```
+Errno::EACCES: Permission denied @ rb_sysopen - db/migrate/...
+```
+
+### Solution
+1. **Check file permissions:**
+   ```bash
+   ls -la db/migrate/
+   # Files should be readable by the Rails process
+   ```
+
+2. **Fix migration directory permissions:**
+   ```bash
+   chmod 755 db/migrate
+   chmod 644 db/migrate/*.rb
+   ```
+
+3. **Database table permissions:**
+   ```sql
+   -- Grant permissions to your Rails database user
+   GRANT ALL PRIVILEGES ON migration_guard_records TO your_rails_user;
+   ```
+
+4. **For shared hosting environments:**
+   - Ensure the web server user has read access to the Rails root directory
+   - Check with your hosting provider about file permission requirements
+
+## Database Connection Errors
+
+### Problem
+```
+ActiveRecord::ConnectionNotEstablished
+Could not find migration_guard_records table
+```
+
+### Solution
+1. **Run the installation generator:**
+   ```bash
+   rails generate migration_guard:install
+   rails db:migrate
+   ```
+
+2. **Verify the table exists:**
+   ```bash
+   rails console
+   > ActiveRecord::Base.connection.tables.include?('migration_guard_records')
+   # Should return true
+   ```
+
+3. **For multiple databases:**
+   ```ruby
+   # Ensure MigrationGuard uses the correct database
+   class MigrationGuardRecord < ApplicationRecord
+     establish_connection :primary # or your specific database
+   end
+   ```
+
+4. **Connection pool issues:**
+   ```ruby
+   # config/database.yml
+   development:
+     pool: 10  # Increase if you see connection timeouts
+   ```
+
+## Migration Version Conflicts
+
+### Problem
+```
+ActiveRecord::RecordNotUnique: Duplicate entry '20240101000001' for key 'index_migration_guard_records_on_version'
+```
+
+### Solution
+1. **Clean up duplicate records:**
+   ```ruby
+   # In rails console
+   duplicates = MigrationGuard::MigrationGuardRecord
+     .group(:version)
+     .having('COUNT(*) > 1')
+     .pluck(:version)
+   
+   duplicates.each do |version|
+     records = MigrationGuard::MigrationGuardRecord.where(version: version)
+     records.offset(1).destroy_all  # Keep the first, remove others
+   end
+   ```
+
+2. **Reset migration tracking:**
+   ```bash
+   rails db:migration:cleanup FORCE=true
+   ```
+
+3. **Prevent future conflicts:**
+   - Always use Rails generators for migrations: `rails g migration AddFieldToModel`
+   - Avoid manually creating migration files
+   - Use timestamp-based migration versions (Rails default)
+
+## Performance Issues
+
+### Problem
+Status checks or rollback operations are slow with large migration histories.
+
+### Solution
+1. **Add database indexes (if missing):**
+   ```ruby
+   class AddIndexesToMigrationGuardRecords < ActiveRecord::Migration[7.0]
+     def change
+       add_index :migration_guard_records, :status, unless_exists: true
+       add_index :migration_guard_records, :created_at, unless_exists: true
+       add_index :migration_guard_records, [:branch, :status], unless_exists: true
+     end
+   end
+   ```
+
+2. **Enable auto-cleanup:**
+   ```ruby
+   MigrationGuard.configure do |config|
+     config.auto_cleanup = true
+     config.cleanup_after_days = 30  # Remove old rolled_back records
+   end
+   ```
+
+3. **Optimize Git operations:**
+   ```bash
+   # Ensure your Git repository is optimized
+   git gc --aggressive
+   git repack -a -d
+   ```
+
+4. **For very large projects:**
+   - Consider limiting the branches checked:
+   ```ruby
+   config.target_branches = ['main']  # Only check against main branch
+   ```
+
+## Rails Version Compatibility
+
+### Known Issues by Rails Version
+
+#### Rails 6.1
+- Minimum supported version
+- All features work as expected
+
+#### Rails 7.0+
+- Fully compatible
+- Supports multiple databases
+- Works with async migrations
+
+#### Rails 8.0+
+- Requires sqlite3 gem version 2.1.0 or higher
+- Compatible with new migration versioning
+
+### Solution for Version Issues
+1. **Check your Rails version:**
+   ```bash
+   rails --version
+   ```
+
+2. **Update the gem if needed:**
+   ```ruby
+   # Gemfile
+   gem 'rails-migration-guard', '~> 2.0'  # Check latest version
+   ```
+
+3. **For older Rails versions:**
+   ```ruby
+   # Use an older version of the gem
+   gem 'rails-migration-guard', '~> 1.0'  # For Rails < 6.1
+   ```
+
+## Common Error Messages
+
+### "No main branch found"
+```
+MigrationGuard::GitError: No main branch found. Tried: main, master, trunk
+```
+
+**Solution:**
+```ruby
+# Configure your main branch name
+MigrationGuard.configure do |config|
+  config.main_branch_names = %w[develop production custom-main]
+end
+```
+
+### "Orphaned migrations detected"
+This is a warning, not an error. It means you have migrations that exist locally but not in your main branch.
+
+**Solutions:**
+1. Review the orphaned migrations: `rails db:migration:status`
+2. Roll them back if not needed: `rails db:migration:rollback_orphaned`
+3. Or commit and push them to your main branch
+
+### "Git user email not configured"
+```
+MigrationGuard::GitError: Git user email not configured
+```
+
+**Solution:**
+```bash
+git config --global user.email "you@example.com"
+git config --global user.name "Your Name"
+```
+
+### "Migration file not found in branch"
+This occurs when checking for migrations across branches.
+
+**Solution:**
+1. Fetch latest branches: `git fetch --all`
+2. Ensure branches are up to date: `git pull origin main`
+3. Check if migration was renamed or deleted
+
+## Getting Help
+
+If you're still experiencing issues:
+
+1. **Run the diagnostic tool:**
+   ```bash
+   rails db:migration:doctor
+   ```
+
+2. **Check the gem version:**
+   ```bash
+   bundle show rails-migration-guard
+   ```
+
+3. **Enable debug logging:**
+   ```ruby
+   # In Rails console
+   MigrationGuard.logger.level = Logger::DEBUG
+   ```
+
+4. **Report issues:**
+   - GitHub Issues: https://github.com/your-org/rails-migration-guard/issues
+   - Include output from `rails db:migration:doctor`
+   - Provide Rails version, Ruby version, and database type
+
+## Prevention Tips
+
+1. **Regular maintenance:**
+   - Run `rails db:migration:status` before deploying
+   - Clean up old migrations periodically
+   - Keep your branches synchronized
+
+2. **Team practices:**
+   - Always create migrations on feature branches
+   - Merge migration changes promptly
+   - Communicate about migration conflicts
+
+3. **CI/CD integration:**
+   - Add migration checks to your CI pipeline
+   - Block deployments with orphaned migrations
+   - Automate cleanup in staging environments

--- a/lib/generators/migration_guard/install/templates/migration_guard.rb
+++ b/lib/generators/migration_guard/install/templates/migration_guard.rb
@@ -27,4 +27,10 @@ MigrationGuard.configure do |config|
 
   # Main branch names to check against (in order of preference)
   config.main_branch_names = %w[main master trunk]
+  
+  # Target branches to compare migrations against
+  # When set, migrations will be compared against all specified branches
+  # instead of just the main branch. This is useful for teams that use
+  # multiple long-lived branches (e.g., develop, staging, production)
+  # config.target_branches = %w[main develop staging]
 end

--- a/spec/lib/migration_guard/git_integration_spec.rb
+++ b/spec/lib/migration_guard/git_integration_spec.rb
@@ -193,4 +193,87 @@ RSpec.describe MigrationGuard::GitIntegration do
       expect(git_integration.stash_required?).to be false
     end
   end
+
+  describe "#target_branches" do
+    context "when target_branches is configured" do
+      before do
+        allow(MigrationGuard.configuration).to receive(:effective_target_branches)
+          .and_return(%w[main develop staging])
+      end
+
+      it "returns the configured target branches" do
+        expect(git_integration.target_branches).to eq(%w[main develop staging])
+      end
+    end
+  end
+
+  describe "#migrations_in_branches" do
+    before do
+      allow(git_integration).to receive(:target_branches).and_return(%w[main develop])
+    end
+
+    it "returns migrations for each branch" do
+      stub_system_call(
+        "git ls-tree -r main --name-only db/migrate/ 2>&1",
+        "db/migrate/001_create_users.rb\ndb/migrate/002_add_email.rb\n",
+        success: true
+      )
+      stub_system_call(
+        "git ls-tree -r develop --name-only db/migrate/ 2>&1",
+        "db/migrate/001_create_users.rb\ndb/migrate/003_add_profile.rb\n",
+        success: true
+      )
+
+      result = git_integration.migrations_in_branches
+
+      expect(result).to eq({
+        "main" => ["001_create_users.rb", "002_add_email.rb"],
+        "develop" => ["001_create_users.rb", "003_add_profile.rb"]
+      })
+    end
+
+    it "handles errors for specific branches" do
+      stub_system_call(
+        "git ls-tree -r main --name-only db/migrate/ 2>&1",
+        "db/migrate/001_create_users.rb\n",
+        success: true
+      )
+      stub_system_call(
+        "git ls-tree -r develop --name-only db/migrate/ 2>&1",
+        "fatal: Not a valid object name develop\n",
+        success: false
+      )
+
+      result = git_integration.migrations_in_branches
+
+      expect(result["main"]).to eq(["001_create_users.rb"])
+      expect(result["develop"]).to eq({ error: "Failed to list migrations in branch develop: fatal: Not a valid object name develop\n" })
+    end
+  end
+
+  describe "#migration_versions_in_branches" do
+    before do
+      allow(git_integration).to receive(:target_branches).and_return(%w[main develop])
+    end
+
+    it "returns version numbers for each branch" do
+      stub_system_call(
+        "git ls-tree -r main --name-only db/migrate/ 2>&1",
+        "db/migrate/20240101000001_create_users.rb\ndb/migrate/20240102000002_add_email.rb\n",
+        success: true
+      )
+      stub_system_call(
+        "git ls-tree -r develop --name-only db/migrate/ 2>&1",
+        "db/migrate/20240101000001_create_users.rb\ndb/migrate/20240103000003_add_profile.rb\n",
+        success: true
+      )
+
+      result = git_integration.migration_versions_in_branches
+
+      expect(result).to eq({
+        "main" => %w[20240101000001 20240102000002],
+        "develop" => %w[20240101000001 20240103000003]
+      })
+    end
+  end
 end

--- a/spec/lib/migration_guard/reporter_multi_branch_spec.rb
+++ b/spec/lib/migration_guard/reporter_multi_branch_spec.rb
@@ -1,0 +1,252 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe MigrationGuard::Reporter, "multi-branch support" do
+  let(:reporter) { described_class.new }
+  let(:git_integration) { instance_double(MigrationGuard::GitIntegration) }
+
+  before do
+    allow(MigrationGuard::GitIntegration).to receive(:new).and_return(git_integration)
+    allow(git_integration).to receive(:main_branch).and_return("main")
+    
+    # Enable multi-branch mode
+    allow(MigrationGuard.configuration).to receive(:target_branches)
+      .and_return(%w[main develop staging])
+    allow(git_integration).to receive(:target_branches)
+      .and_return(%w[main develop staging])
+  end
+
+  def create_migration_guard_record(attributes = {})
+    MigrationGuard::MigrationGuardRecord.create!({
+      status: "applied",
+      branch: "feature/test",
+      author: "test@example.com"
+    }.merge(attributes))
+  end
+
+  describe "#orphaned_migrations" do
+    context "with multiple target branches" do
+      before do
+        allow(git_integration).to receive(:migration_versions_in_branches).and_return({
+          "main" => %w[001 002],
+          "develop" => %w[001 002 003],
+          "staging" => %w[001 002]
+        })
+      end
+
+      it "considers migrations orphaned only if missing from all branches" do
+        create_migration_guard_record(version: "001", status: "applied")
+        create_migration_guard_record(version: "002", status: "applied")
+        create_migration_guard_record(version: "003", status: "applied")
+        create_migration_guard_record(version: "004", status: "applied")
+
+        orphaned = reporter.orphaned_migrations
+
+        expect(orphaned.map(&:version)).to eq(["004"])
+      end
+
+      it "considers migration synced if present in any branch" do
+        create_migration_guard_record(version: "001", status: "applied")
+        create_migration_guard_record(version: "003", status: "applied")
+
+        orphaned = reporter.orphaned_migrations
+
+        expect(orphaned).to be_empty
+      end
+    end
+  end
+
+  describe "#missing_migrations" do
+    context "with multiple target branches" do
+      before do
+        allow(git_integration).to receive(:migration_versions_in_branches).and_return({
+          "main" => %w[001 002],
+          "develop" => %w[001 002 003],
+          "staging" => %w[001 002 004]
+        })
+      end
+
+      it "returns missing migrations by branch" do
+        create_migration_guard_record(version: "001", status: "applied")
+
+        missing = reporter.missing_migrations
+
+        expect(missing).to eq({
+          "main" => %w[002],
+          "develop" => %w[002 003],
+          "staging" => %w[002 004]
+        })
+      end
+
+      it "excludes branches with no missing migrations" do
+        create_migration_guard_record(version: "001", status: "applied")
+        create_migration_guard_record(version: "002", status: "applied")
+
+        missing = reporter.missing_migrations
+
+        expect(missing).to eq({
+          "develop" => %w[003],
+          "staging" => %w[004]
+        })
+      end
+
+      it "returns empty hash when all migrations are applied" do
+        %w[001 002 003 004].each do |version|
+          create_migration_guard_record(version: version, status: "applied")
+        end
+
+        missing = reporter.missing_migrations
+
+        expect(missing).to eq({})
+      end
+    end
+  end
+
+  describe "#status_report" do
+    context "with multiple target branches" do
+      before do
+        allow(git_integration).to receive(:current_branch).and_return("feature/test")
+        allow(git_integration).to receive(:migration_versions_in_branches).and_return({
+          "main" => %w[001 002],
+          "develop" => %w[001 002 003]
+        })
+        
+        create_migration_guard_record(version: "001", status: "applied")
+        create_migration_guard_record(version: "004", status: "applied")
+      end
+
+      it "returns multi-branch status report" do
+        report = reporter.status_report
+
+        aggregate_failures do
+          expect(report).to include(
+            current_branch: "feature/test",
+            target_branches: %w[main develop staging],
+            orphaned_count: 1,
+            synced_count: 1
+          )
+          expect(report[:missing_by_branch]).to eq({
+            "main" => %w[002],
+            "develop" => %w[002 003]
+          })
+          expect(report[:missing_migrations]).to contain_exactly("002", "003")
+        end
+      end
+    end
+  end
+
+  describe "#format_status_output" do
+    before do
+      allow(git_integration).to receive(:current_branch).and_return("feature/test")
+    end
+
+    context "with missing migrations in multiple branches" do
+      before do
+        allow(git_integration).to receive(:migration_versions_in_branches).and_return({
+          "main" => %w[001 002],
+          "develop" => %w[001 002 003]
+        })
+        
+        create_migration_guard_record(version: "001", status: "applied")
+      end
+
+      it "displays missing migrations by branch" do
+        output = reporter.format_status_output
+
+        aggregate_failures do
+          expect(output).to include("Migration Status (branches: main, develop, staging)")
+          expect(output).to include("Missing Migrations by Branch:")
+          expect(output).to include("main:")
+          expect(output).to include("002")
+          expect(output).to include("develop:")
+          expect(output).to include("003")
+          expect(output).to include("✗ Missing: 2 migrations (in target branches, not local)")
+        end
+      end
+    end
+
+    context "with clean status across all branches" do
+      before do
+        allow(git_integration).to receive(:migration_versions_in_branches).and_return({
+          "main" => %w[001 002],
+          "develop" => %w[001 002],
+          "staging" => %w[001 002]
+        })
+        
+        create_migration_guard_record(version: "001", status: "applied")
+        create_migration_guard_record(version: "002", status: "applied")
+      end
+
+      it "displays synced status" do
+        output = reporter.format_status_output
+
+        expect(output).to include("✓ All migrations synced with main, develop, staging")
+      end
+    end
+
+    context "with orphaned migrations" do
+      before do
+        allow(git_integration).to receive(:migration_versions_in_branches).and_return({
+          "main" => %w[001],
+          "develop" => %w[001],
+          "staging" => %w[001]
+        })
+        
+        create_migration_guard_record(version: "001", status: "applied")
+        create_migration_guard_record(version: "002", status: "applied", branch: "feature/test")
+      end
+
+      it "displays orphaned migrations" do
+        output = reporter.format_status_output
+
+        aggregate_failures do
+          expect(output).to include("⚠ Orphaned: 1 migration (local only)")
+          expect(output).to include("Orphaned Migrations:")
+          expect(output).to include("002")
+        end
+      end
+    end
+  end
+
+  describe "#summary_line" do
+    before do
+      allow(git_integration).to receive(:current_branch).and_return("feature/test")
+    end
+
+    context "with missing migrations from multiple branches" do
+      before do
+        allow(git_integration).to receive(:migration_versions_in_branches).and_return({
+          "main" => %w[001 002],
+          "develop" => %w[001 002 003]
+        })
+        
+        create_migration_guard_record(version: "001", status: "applied")
+      end
+
+      it "generates multi-branch missing summary" do
+        summary = reporter.summary_line
+
+        expect(summary).to eq("MigrationGuard: 2 missing migrations from branches: main, develop")
+      end
+    end
+
+    context "with clean status across all branches" do
+      before do
+        allow(git_integration).to receive(:migration_versions_in_branches).and_return({
+          "main" => %w[001],
+          "develop" => %w[001],
+          "staging" => %w[001]
+        })
+        
+        create_migration_guard_record(version: "001", status: "applied")
+      end
+
+      it "generates multi-branch synced summary" do
+        summary = reporter.summary_line
+
+        expect(summary).to eq("MigrationGuard: All migrations synced with branches: main, develop, staging")
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Summary
This PR implements support for comparing migrations against multiple remote branches, addressing Issue #1.

Key changes:
- Added `target_branches` configuration option
- Enhanced GitIntegration with multi-branch methods
- Updated Reporter to show branch-specific comparisons

## Features
- **Configuration**: New `target_branches` option allows specifying multiple branches to check against
- **GitIntegration**: Added `migrations_in_branches` and `migration_versions_in_branches` methods
- **Reporter**: Enhanced to show which migrations are missing from which specific branches
- **Backward Compatibility**: When `target_branches` is not set, the gem behaves as before (checking against main branch only)

## Test Plan
- [x] Added comprehensive test coverage for multi-branch functionality
- [x] All existing tests pass
- [x] RuboCop checks pass
- [x] Manual testing with multiple branches

## Documentation
- [x] Updated README with configuration examples
- [x] Added comprehensive TROUBLESHOOTING.md guide (Issue #4)
- [x] Updated install generator template

Closes #1
Closes #4

🤖 Generated with [Claude Code](https://claude.ai/code)