### PR TITLE
Add dedicated edge case test job to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,3 +35,27 @@ jobs:
     
     - name: Run linter
       run: bundle exec rubocop
+
+  edge-case-tests:
+    runs-on: ubuntu-latest
+    name: Edge Case Tests
+    strategy:
+      matrix:
+        rails-version: ['7.2', '8.0']
+    env:
+      RAILS_VERSION: ${{ matrix.rails-version }}
+    steps:
+    - uses: actions/checkout@v4
+    
+    - name: Set up Ruby
+      uses: ruby/setup-ruby@v1
+      with:
+        ruby-version: '3.4'
+        bundler-cache: true
+    
+    - name: Run Git Integration Edge Case Tests
+      run: bundle exec rspec spec/lib/migration_guard/git_integration_edge_cases_spec.rb --format documentation
+    
+    - name: Run Integration Test Script
+      run: ruby test_git_integration.rb
+      if: false # Disabled for now since the file is not committed


### PR DESCRIPTION
## Summary
Adds a dedicated CI job for running edge case tests with enhanced visibility and coverage.

## Changes
- New `edge-case-tests` job in CI workflow
- Runs edge case tests explicitly with documentation format
- Tests against both Rails 7.2 and 8.0
- Prepared for future integration test script

## Why This Change?
The edge case tests are comprehensive and test various error scenarios that might not be obvious in the regular test output. Having them run separately with documentation format provides:
- Better visibility into what edge cases are being tested
- Easier debugging when edge case tests fail
- Ability to add more intensive tests without slowing down the main test matrix

## Testing
The edge case tests are already passing in the main test suite. This PR just gives them their own dedicated CI job for better visibility.

Closes #59

🤖 Generated with [Claude Code](https://claude.ai/code)