### PR TITLE
Fix Ruby 3.4.1 compatibility warnings

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -33,5 +33,10 @@ group :development, :test do
   end
 end
 
-# Suppress Ruby 3.5 deprecation warning
-gem "benchmark"
+# Ruby 3.4+ extracted these from stdlib
+if RUBY_VERSION >= "3.4.0"
+  gem "benchmark"
+  gem "bigdecimal"
+  gem "logger"
+  gem "mutex_m"
+end

--- a/README.md
+++ b/README.md
@@ -244,6 +244,23 @@ $ bundle exec rubocop      # Check code style
 $ bundle exec rake         # Run default tasks
 ```
 
+## Known Issues
+
+### Ruby 3.4.1 Compatibility
+
+When using Ruby 3.4.1 with Rails 7.0.x, you may see warnings like:
+
+```
+warning: method redefined; discarding old to_s
+warning: previous definition of to_s was here
+```
+
+These warnings come from ActiveSupport 7.0.x itself and do not affect the functionality of Rails Migration Guard. The warnings are resolved in Rails 7.1+ and Rails 8.0+. If the warnings are bothersome, consider:
+
+1. Upgrading to Rails 7.1 or later
+2. Using Ruby 3.3.x until you can upgrade Rails
+3. Suppressing warnings with `RUBYOPT="-W0"` (not recommended for development)
+
 ## Contributing
 
 1. Fork it (https://github.com/tommy2118/rails-migration-guard/fork)

--- a/rails_migration_guard.gemspec
+++ b/rails_migration_guard.gemspec
@@ -34,10 +34,6 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency "activerecord", ">= 6.1", "< 9.0"
   spec.add_dependency "activesupport", ">= 6.1", "< 9.0"
-  spec.add_dependency "bigdecimal"
-  spec.add_dependency "drb"
-  spec.add_dependency "logger"
-  spec.add_dependency "mutex_m"
   spec.add_dependency "rails", ">= 6.1", "< 9.0"
   spec.add_dependency "rainbow", "~> 3.1"
 

--- a/spec/ruby_3_4_compatibility_spec.rb
+++ b/spec/ruby_3_4_compatibility_spec.rb
@@ -31,7 +31,7 @@ RSpec.describe "Ruby 3.4.1 compatibility", type: :integration do
       skip "Not running on Ruby 3.4+" unless RUBY_VERSION >= "3.4.0"
 
       expect(defined?(Logger)).to be_truthy
-      expect(defined?(Mutex_m)).to be_truthy
+      expect { require "mutex_m" }.not_to raise_error
     end
   end
 end

--- a/spec/ruby_3_4_compatibility_spec.rb
+++ b/spec/ruby_3_4_compatibility_spec.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+# rubocop:disable RSpec/DescribeClass
+RSpec.describe "Ruby 3.4.1 compatibility", type: :integration do
+  it "loads the gem without errors" do
+    expect { require "rails_migration_guard" }.not_to raise_error
+  end
+
+  it "can track migrations without errors" do
+    tracker = MigrationGuard::Tracker.new
+    expect { tracker.track_migration("20240115123456", :up) }.not_to raise_error
+  end
+
+  it "can report status without errors" do
+    reporter = MigrationGuard::Reporter.new
+    expect { reporter.status_report }.not_to raise_error
+  end
+
+  context "when running with Ruby 3.4+" do
+    it "has access to extracted stdlib gems" do
+      skip "Not running on Ruby 3.4+" unless RUBY_VERSION >= "3.4.0"
+
+      expect(defined?(Logger)).to be_truthy
+      expect(defined?(Mutex_m)).to be_truthy
+    end
+  end
+end
+# rubocop:enable RSpec/DescribeClass

--- a/spec/ruby_3_4_compatibility_spec.rb
+++ b/spec/ruby_3_4_compatibility_spec.rb
@@ -14,14 +14,15 @@ RSpec.describe "Ruby 3.4.1 compatibility", type: :integration do
   end
 
   it "can report status without errors" do
-    reporter = MigrationGuard::Reporter.new
-
     # Mock the git integration to avoid git-related errors in test
     git_integration = instance_double(MigrationGuard::GitIntegration)
     allow(MigrationGuard::GitIntegration).to receive(:new).and_return(git_integration)
     allow(git_integration).to receive_messages(main_branch: "master", target_branches: ["master"],
-                                               migration_versions_in_branches: { "master" => [] })
+                                               migration_versions_in_branches: { "master" => [] },
+                                               current_branch: "master",
+                                               migration_versions_in_trunk: [])
 
+    reporter = MigrationGuard::Reporter.new
     expect { reporter.status_report }.not_to raise_error
   end
 

--- a/spec/ruby_3_4_compatibility_spec.rb
+++ b/spec/ruby_3_4_compatibility_spec.rb
@@ -15,6 +15,13 @@ RSpec.describe "Ruby 3.4.1 compatibility", type: :integration do
 
   it "can report status without errors" do
     reporter = MigrationGuard::Reporter.new
+
+    # Mock the git integration to avoid git-related errors in test
+    git_integration = instance_double(MigrationGuard::GitIntegration)
+    allow(MigrationGuard::GitIntegration).to receive(:new).and_return(git_integration)
+    allow(git_integration).to receive_messages(main_branch: "master", target_branches: ["master"],
+                                               migration_versions_in_branches: { "master" => [] })
+
     expect { reporter.status_report }.not_to raise_error
   end
 


### PR DESCRIPTION
## Summary
- Resolves warnings when using Ruby 3.4.1 with Rails 7.0.x
- Adds compatibility test suite to ensure functionality works correctly
- Documents known ActiveSupport warnings that are outside our control

## Details

This PR addresses issue #52 by:

1. Removing unnecessary stdlib gem dependencies from the gemspec that were causing conflicts
2. Adding conditional stdlib gem dependencies to the Gemfile for Ruby 3.4+ environments
3. Creating a dedicated test suite to verify Ruby 3.4.1 compatibility
4. Documenting the known ActiveSupport warnings in the README

The remaining warnings about method redefinitions come from ActiveSupport 7.0.x itself and are resolved in Rails 7.1+. These warnings do not affect the functionality of Rails Migration Guard.

## Test plan
- [x] All existing tests pass
- [x] New Ruby 3.4.1 compatibility tests pass
- [x] RuboCop linting passes
- [x] Tested manually with Ruby 3.4.1 and Rails 7.0.x

Fixes #52

🤖 Generated with [Claude Code](https://claude.ai/code)