### PR TITLE
Add Quick Start to navigation and fix documentation links

### DIFF
--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -14,6 +14,8 @@ plugins: []
 navigation:
   - title: "Home"
     url: "/"
+  - title: "Quick Start"
+    url: "/quick-start.html"
   - title: "Documentation"
     url: "/docs/"
   - title: "Installation"

--- a/docs/_layouts/default.html
+++ b/docs/_layouts/default.html
@@ -172,6 +172,7 @@
                 <div>
                     <h3 class="text-sm font-semibold text-gray-900 tracking-wider uppercase mb-4">Resources</h3>
                     <ul class="space-y-2">
+                        <li><a href="{{ '/quick-start.html' | relative_url }}" class="text-gray-600 hover:text-brand-600">Quick Start</a></li>
                         <li><a href="{{ '/docs/' | relative_url }}" class="text-gray-600 hover:text-brand-600">Documentation</a></li>
                         <li><a href="{{ '/examples/' | relative_url }}" class="text-gray-600 hover:text-brand-600">Examples</a></li>
                         <li><a href="https://github.com/tommy2118/rails-migration-guard" class="text-gray-600 hover:text-brand-600">GitHub</a></li>

--- a/docs/docker-ci-support.md
+++ b/docs/docker-ci-support.md
@@ -4,8 +4,8 @@ Rails Migration Guard now provides full support for Docker containers and CI/CD 
 
 > **Related Documentation:**
 > - [CI Integration Guide](ci-integration.md) - Detailed CI/CD setup
-> - [Troubleshooting Guide](troubleshooting.md) - Common issues and solutions
-> - [Configuration Reference](configuration.md) - All configuration options
+> - [Troubleshooting Guide](troubleshooting.html) - Common issues and solutions
+> - [Configuration Reference](configuration.html) - All configuration options
 
 ## Automatic TTY Detection
 

--- a/docs/quick-start.html
+++ b/docs/quick-start.html
@@ -519,7 +519,7 @@ end</code></pre>
                 <p class="text-gray-600 text-sm">Real-world usage patterns and recipes</p>
             </a>
             
-            <a href="{{ '/ci-integration' | relative_url }}" class="bg-white rounded-lg shadow-md hover:shadow-lg transition-all duration-200 p-6 border border-gray-200 hover:border-brand-200 transform hover:-translate-y-1">
+            <a href="{{ '/ci-integration.html' | relative_url }}" class="bg-white rounded-lg shadow-md hover:shadow-lg transition-all duration-200 p-6 border border-gray-200 hover:border-brand-200 transform hover:-translate-y-1">
                 <div class="flex items-center mb-4 text-brand-600">
                     <svg class="w-6 h-6 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                         <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M10 20l4-16m4 4l4 4-4 4M6 16l-4-4 4-4"></path>
@@ -529,7 +529,7 @@ end</code></pre>
                 <p class="text-gray-600 text-sm">Automate checks in your pipeline</p>
             </a>
             
-            <a href="{{ '/github-actions' | relative_url }}" class="bg-white rounded-lg shadow-md hover:shadow-lg transition-all duration-200 p-6 border border-gray-200 hover:border-brand-200 transform hover:-translate-y-1">
+            <a href="{{ '/github-actions.html' | relative_url }}" class="bg-white rounded-lg shadow-md hover:shadow-lg transition-all duration-200 p-6 border border-gray-200 hover:border-brand-200 transform hover:-translate-y-1">
                 <div class="flex items-center mb-4 text-brand-600">
                     <svg class="w-6 h-6 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                         <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13 10V3L4 14h7v7l9-11h-7z"></path>


### PR DESCRIPTION
## Summary
- Add Quick Start guide to main navigation menu for improved discoverability
- Add Quick Start link to footer resources section
- Fix links in quick-start.html to use .html extensions
- Update links in docker-ci-support.md to use .html extensions
- Ensure consistent navigation between documentation pages

## Changes
- Updated  to add Quick Start to main navigation
- Added Quick Start link to the Resources section in the footer
- Fixed links in quick-start.html to use .html extensions for CI Integration and GitHub Actions
- Updated links in docker-ci-support.md to use .html extensions for related docs

These changes make the Quick Start guide more accessible to users and ensure consistent navigation throughout the documentation with proper file extensions.

🤖 Generated with [Claude Code](https://claude.ai/code)