### PR TITLE
Update repository URL references in GitHub Actions docs

### DIFF
--- a/docs/github-actions.html
+++ b/docs/github-actions.html
@@ -912,7 +912,7 @@ jobs:
         </div>
         
         <div class="grid grid-cols-1 md:grid-cols-3 gap-6">
-            <a href="https://github.com/rails-migration-guard/rails-migration-guard/issues" class="bg-white rounded-lg shadow-md hover:shadow-lg transition-all duration-200 p-6 border border-gray-200 hover:border-brand-200 transform hover:-translate-y-1">
+            <a href="https://github.com/tommy2118/rails-migration-guard/issues" class="bg-white rounded-lg shadow-md hover:shadow-lg transition-all duration-200 p-6 border border-gray-200 hover:border-brand-200 transform hover:-translate-y-1">
                 <div class="flex items-center mb-4 text-brand-600">
                     <svg class="w-6 h-6 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                         <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z"></path>


### PR DESCRIPTION
## Summary
- Fix repository URL to point to tommy2118/rails-migration-guard instead of rails-migration-guard/rails-migration-guard
- Update GitHub issues URL in documentation

## Context
This PR includes the remaining changes needed from PR #119 that hadn't yet been incorporated into master.

Fixes part of #116 (Documentation Improvements)

🤖 Generated with [Claude Code](https://claude.ai/code)