### PR TITLE
feat: add visual feedback for sandbox mode (#91)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,9 +25,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Shows completion message after rollback: "⚠️ SANDBOX: Database changes rolled back"
   - Added sandbox mode status to `rails db:migration:doctor` diagnostic checks
   - Added sandbox mode indicator to `rails db:migration:status` output
-  - Configurable via environment variables:
+  - Configurable via environment variables (supports multiple truthy values: true, 1, yes):
     - `MIGRATION_GUARD_SANDBOX_QUIET=true` - Disable all sandbox feedback
     - `MIGRATION_GUARD_SANDBOX_VERBOSE=true` - Enable feedback in test environment
+  - Consistent output method: uses Rails logger when available, falls back to stdout
   - Improves user experience by preventing confusion about sandbox behavior
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Colorized output with clear status indicators (✓/⚠/✗)
   - Comprehensive validation of schema consistency
   - Guides new developers through proper environment setup
+- **Visual Feedback for Sandbox Mode** (#91) - Enhanced sandbox mode with clear user feedback:
+  - Displays prominent notifications when sandbox mode is active during migrations
+  - Shows "🧪 SANDBOX MODE ACTIVE" message before migration execution
+  - Shows completion message after rollback: "⚠️ SANDBOX: Database changes rolled back"
+  - Added sandbox mode status to `rails db:migration:doctor` diagnostic checks
+  - Added sandbox mode indicator to `rails db:migration:status` output
+  - Configurable via environment variables:
+    - `MIGRATION_GUARD_SANDBOX_QUIET=true` - Disable all sandbox feedback
+    - `MIGRATION_GUARD_SANDBOX_VERBOSE=true` - Enable feedback in test environment
+  - Improves user experience by preventing confusion about sandbox behavior
 
 ### Fixed
 - **Warning Consolidation** (#105, #127) - Fixed warning spam during multiple migrations:

--- a/lib/migration_guard/diagnostic_runner.rb
+++ b/lib/migration_guard/diagnostic_runner.rb
@@ -28,6 +28,7 @@ module MigrationGuard
       check_schema_consistency
       check_missing_migration_files
       check_environment_configuration
+      check_sandbox_mode
 
       print_summary
     end
@@ -279,6 +280,18 @@ module MigrationGuard
       end
     end
     # rubocop:enable Metrics/MethodLength
+
+    def check_sandbox_mode
+      config = MigrationGuard.configuration
+
+      if config.sandbox_mode
+        add_warning("Sandbox mode is enabled",
+                    "Migrations will be rolled back after execution. Disable sandbox_mode for real changes")
+        print_check("Sandbox mode", :warning, "ACTIVE (changes will be rolled back)")
+      else
+        print_check("Sandbox mode", :success, "disabled")
+      end
+    end
 
     def print_check(name, status, details = nil)
       symbol = case status

--- a/lib/migration_guard/migration_extension.rb
+++ b/lib/migration_guard/migration_extension.rb
@@ -1,6 +1,12 @@
 # frozen_string_literal: true
 
 module MigrationGuard
+  # Constants for sandbox mode messages
+  module SandboxMessages
+    START = "🧪 SANDBOX MODE ACTIVE - Database changes will be rolled back"
+    COMPLETE = "⚠️  SANDBOX: Database changes rolled back. Schema.rb updated for inspection."
+  end
+
   module MigrationExtension
     def self.prepended(base)
       base.singleton_class.prepend(ClassMethods)
@@ -56,25 +62,41 @@ module MigrationGuard
     def display_sandbox_start_message
       return unless should_display_sandbox_messages?
 
-      require_relative "colorizer"
-      puts MigrationGuard::Colorizer.info("🧪 SANDBOX MODE ACTIVE - Database changes will be rolled back") # rubocop:disable Rails/Output
+      display_sandbox_message(SandboxMessages::START, :info)
     end
 
     def display_sandbox_complete_message
       return unless should_display_sandbox_messages?
 
+      display_sandbox_message(SandboxMessages::COMPLETE, :warn)
+    end
+
+    def display_sandbox_message(message, logger_level)
       require_relative "colorizer"
-      # rubocop:disable Layout/LineLength, Rails/Output
-      puts MigrationGuard::Colorizer.warning("⚠️  SANDBOX: Database changes rolled back. Schema.rb updated for inspection.")
-      # rubocop:enable Layout/LineLength, Rails/Output
+      
+      # Map logger levels to colorizer methods
+      colorizer_method = logger_level == :warn ? :warning : logger_level
+      
+      if Rails.logger
+        Rails.logger.public_send(logger_level, MigrationGuard::Colorizer.public_send(colorizer_method, message))
+      else
+        puts MigrationGuard::Colorizer.public_send(colorizer_method, message) # rubocop:disable Rails/Output
+      end
     end
 
     def should_display_sandbox_messages?
-      # Display messages unless explicitly disabled or in test environment
-      return false if ENV["MIGRATION_GUARD_SANDBOX_QUIET"] == "true"
-      return false if Rails.env.test? && !ENV["MIGRATION_GUARD_SANDBOX_VERBOSE"]
+      # Respect explicit quiet flag (supports multiple true values)
+      return false if env_var_truthy?("MIGRATION_GUARD_SANDBOX_QUIET")
+      
+      # Show in test only if explicitly verbose
+      return false if Rails.env.test? && !env_var_truthy?("MIGRATION_GUARD_SANDBOX_VERBOSE")
 
       true
+    end
+
+    def env_var_truthy?(env_var_name)
+      value = ENV[env_var_name]&.downcase
+      %w[true 1 yes].include?(value)
     end
   end
 end

--- a/lib/migration_guard/migration_extension.rb
+++ b/lib/migration_guard/migration_extension.rb
@@ -73,10 +73,10 @@ module MigrationGuard
 
     def display_sandbox_message(message, logger_level)
       require_relative "colorizer"
-      
+
       # Map logger levels to colorizer methods
       colorizer_method = logger_level == :warn ? :warning : logger_level
-      
+
       if Rails.logger
         Rails.logger.public_send(logger_level, MigrationGuard::Colorizer.public_send(colorizer_method, message))
       else
@@ -87,7 +87,7 @@ module MigrationGuard
     def should_display_sandbox_messages?
       # Respect explicit quiet flag (supports multiple true values)
       return false if env_var_truthy?("MIGRATION_GUARD_SANDBOX_QUIET")
-      
+
       # Show in test only if explicitly verbose
       return false if Rails.env.test? && !env_var_truthy?("MIGRATION_GUARD_SANDBOX_VERBOSE")
 

--- a/lib/migration_guard/reporter.rb
+++ b/lib/migration_guard/reporter.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require_relative "colorizer"
+require_relative "migration_extension"
 
 module MigrationGuard
   class Reporter # rubocop:disable Metrics/ClassLength
@@ -230,7 +231,7 @@ module MigrationGuard
 
       # Add sandbox mode indicator
       if MigrationGuard.configuration.sandbox_mode
-        output << Colorizer.warning("🧪 SANDBOX MODE ACTIVE - Changes will be rolled back")
+        output << Colorizer.warning(MigrationGuard::SandboxMessages::START)
       end
 
       output << ("═" * 55)

--- a/lib/migration_guard/reporter.rb
+++ b/lib/migration_guard/reporter.rb
@@ -227,6 +227,12 @@ module MigrationGuard
       else
         output << Colorizer.bold("Migration Status (#{report[:main_branch]} branch)")
       end
+
+      # Add sandbox mode indicator
+      if MigrationGuard.configuration.sandbox_mode
+        output << Colorizer.warning("🧪 SANDBOX MODE ACTIVE - Changes will be rolled back")
+      end
+
       output << ("═" * 55)
     end
 

--- a/lib/migration_guard/reporter.rb
+++ b/lib/migration_guard/reporter.rb
@@ -230,9 +230,7 @@ module MigrationGuard
       end
 
       # Add sandbox mode indicator
-      if MigrationGuard.configuration.sandbox_mode
-        output << Colorizer.warning(MigrationGuard::SandboxMessages::START)
-      end
+      output << Colorizer.warning(MigrationGuard::SandboxMessages::START) if MigrationGuard.configuration.sandbox_mode
 
       output << ("═" * 55)
     end

--- a/spec/lib/migration_guard/diagnostic_runner_spec.rb
+++ b/spec/lib/migration_guard/diagnostic_runner_spec.rb
@@ -335,5 +335,38 @@ RSpec.describe MigrationGuard::DiagnosticRunner do
         end
       end
     end
+
+    context "when testing sandbox mode" do
+      context "when sandbox mode is enabled" do
+        before do
+          allow(MigrationGuard.configuration).to receive(:sandbox_mode).and_return(true)
+        end
+
+        it "reports sandbox mode as active with warning" do
+          runner.run_all_checks
+
+          output = io.string
+          aggregate_failures do
+            expect(output).to include("⚠ Sandbox mode: ACTIVE (changes will be rolled back)")
+            expect(output).to include("Warnings:")
+            expect(output).to include("Sandbox mode is enabled")
+            expect(output).to include("Migrations will be rolled back after execution")
+          end
+        end
+      end
+
+      context "when sandbox mode is disabled" do
+        before do
+          allow(MigrationGuard.configuration).to receive(:sandbox_mode).and_return(false)
+        end
+
+        it "reports sandbox mode as disabled" do
+          runner.run_all_checks
+
+          output = io.string
+          expect(output).to include("✓ Sandbox mode: disabled")
+        end
+      end
+    end
   end
 end

--- a/spec/lib/migration_guard/docker_support_spec.rb
+++ b/spec/lib/migration_guard/docker_support_spec.rb
@@ -35,7 +35,10 @@ RSpec.describe "Docker and CI Support" do
       end
 
       it "automatically switches RecoveryExecutor to non-interactive mode" do
-        expect(Rails.logger).to receive(:info)
+        # Rails.logger might be nil in test environment, so we need to provide a logger
+        logger = instance_double(Logger)
+        allow(Rails).to receive(:logger).and_return(logger)
+        expect(logger).to receive(:info)
           .with("[MigrationGuard] Non-TTY environment detected, running in non-interactive mode")
         executor = MigrationGuard::RecoveryExecutor.new
         expect(executor.send(:interactive?)).to be false

--- a/spec/lib/migration_guard/reporter_sandbox_spec.rb
+++ b/spec/lib/migration_guard/reporter_sandbox_spec.rb
@@ -32,7 +32,7 @@ RSpec.describe MigrationGuard::Reporter, "sandbox mode indicator" do
 
         aggregate_failures do
           expect(output).to include("Migration Status (main branch)")
-          expect(output).to include("🧪 SANDBOX MODE ACTIVE - Changes will be rolled back")
+          expect(output).to include(MigrationGuard::SandboxMessages::START)
           expect(output).to include("═" * 55)
         end
       end
@@ -68,7 +68,7 @@ RSpec.describe MigrationGuard::Reporter, "sandbox mode indicator" do
 
         aggregate_failures do
           expect(output).to include("Migration Status (branches: main, develop)")
-          expect(output).to include("🧪 SANDBOX MODE ACTIVE - Changes will be rolled back")
+          expect(output).to include(MigrationGuard::SandboxMessages::START)
           expect(output).to include("═" * 55)
         end
       end

--- a/spec/lib/migration_guard/reporter_sandbox_spec.rb
+++ b/spec/lib/migration_guard/reporter_sandbox_spec.rb
@@ -1,0 +1,77 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+# rubocop:disable RSpec/SpecFilePathFormat, RSpec/DescribeMethod
+RSpec.describe MigrationGuard::Reporter, "sandbox mode indicator" do
+  # rubocop:enable RSpec/SpecFilePathFormat, RSpec/DescribeMethod
+  let(:reporter) { described_class.new }
+  let(:git_integration) { instance_double(MigrationGuard::GitIntegration) }
+
+  before do
+    allow(MigrationGuard::GitIntegration).to receive(:new).and_return(git_integration)
+    allow(git_integration).to receive_messages(
+      current_branch: "feature/test",
+      main_branch: "main",
+      migration_versions_in_trunk: [],
+      migration_versions_in_branches: {}
+    )
+
+    # Disable colorization for testing
+    allow(MigrationGuard::Colorizer).to receive(:colorize_output?).and_return(false)
+  end
+
+  describe "#format_status_output" do
+    context "when sandbox mode is enabled" do
+      before do
+        allow(MigrationGuard.configuration).to receive(:sandbox_mode).and_return(true)
+      end
+
+      it "includes sandbox mode indicator in the status output" do
+        output = reporter.format_status_output
+
+        aggregate_failures do
+          expect(output).to include("Migration Status (main branch)")
+          expect(output).to include("🧪 SANDBOX MODE ACTIVE - Changes will be rolled back")
+          expect(output).to include("═" * 55)
+        end
+      end
+    end
+
+    context "when sandbox mode is disabled" do
+      before do
+        allow(MigrationGuard.configuration).to receive(:sandbox_mode).and_return(false)
+      end
+
+      it "does not include sandbox mode indicator" do
+        output = reporter.format_status_output
+
+        aggregate_failures do
+          expect(output).to include("Migration Status (main branch)")
+          expect(output).not_to include("SANDBOX MODE")
+          expect(output).to include("═" * 55)
+        end
+      end
+    end
+
+    context "with target branches configured and sandbox mode enabled" do
+      before do
+        allow(MigrationGuard.configuration).to receive_messages(
+          sandbox_mode: true,
+          target_branches: %w[main develop]
+        )
+        allow(git_integration).to receive(:target_branches).and_return(%w[main develop])
+      end
+
+      it "includes sandbox mode indicator with multi-branch status" do
+        output = reporter.format_status_output
+
+        aggregate_failures do
+          expect(output).to include("Migration Status (branches: main, develop)")
+          expect(output).to include("🧪 SANDBOX MODE ACTIVE - Changes will be rolled back")
+          expect(output).to include("═" * 55)
+        end
+      end
+    end
+  end
+end

--- a/spec/lib/migration_guard/sandbox_visual_feedback_spec.rb
+++ b/spec/lib/migration_guard/sandbox_visual_feedback_spec.rb
@@ -31,6 +31,38 @@ RSpec.describe MigrationGuard::MigrationExtension, "sandbox visual feedback" do
     allow(connection).to receive(:transaction).and_yield
   end
 
+  describe "sandbox mode constants" do
+    it "has defined sandbox message constants" do
+      expect(MigrationGuard::SandboxMessages::START).to eq("🧪 SANDBOX MODE ACTIVE - Database changes will be rolled back")
+      expect(MigrationGuard::SandboxMessages::COMPLETE).to eq("⚠️  SANDBOX: Database changes rolled back. Schema.rb updated for inspection.")
+    end
+  end
+
+  describe "environment variable helper methods" do
+    describe "#env_var_truthy?" do
+      it "returns true for various truthy values" do
+        %w[true TRUE True 1 yes YES Yes].each do |value|
+          ENV["TEST_VAR"] = value
+          expect(migration_instance.send(:env_var_truthy?, "TEST_VAR")).to be true
+        end
+        ENV.delete("TEST_VAR")
+      end
+
+      it "returns false for falsy values" do
+        %w[false FALSE False 0 no NO No anything_else].each do |value|
+          ENV["TEST_VAR"] = value
+          expect(migration_instance.send(:env_var_truthy?, "TEST_VAR")).to be false
+        end
+        ENV.delete("TEST_VAR")
+      end
+
+      it "returns false for nil/unset values" do
+        ENV.delete("TEST_VAR")
+        expect(migration_instance.send(:env_var_truthy?, "TEST_VAR")).to be false
+      end
+    end
+  end
+
   describe "sandbox mode helper methods" do
     context "when testing should_display_sandbox_messages?" do
       it "returns true in development environment" do
@@ -39,11 +71,22 @@ RSpec.describe MigrationGuard::MigrationExtension, "sandbox visual feedback" do
         expect(migration_instance.send(:should_display_sandbox_messages?)).to be true
       end
 
-      it "returns false when MIGRATION_GUARD_SANDBOX_QUIET is set" do
+      it "returns false when MIGRATION_GUARD_SANDBOX_QUIET is set to various truthy values" do
         allow(Rails).to receive(:env).and_return(ActiveSupport::StringInquirer.new("development"))
-        ENV["MIGRATION_GUARD_SANDBOX_QUIET"] = "true"
+        
+        %w[true TRUE 1 yes YES].each do |value|
+          ENV["MIGRATION_GUARD_SANDBOX_QUIET"] = value
+          expect(migration_instance.send(:should_display_sandbox_messages?)).to be false
+        end
 
-        expect(migration_instance.send(:should_display_sandbox_messages?)).to be false
+        ENV.delete("MIGRATION_GUARD_SANDBOX_QUIET")
+      end
+
+      it "returns true when MIGRATION_GUARD_SANDBOX_QUIET is set to falsy values" do
+        allow(Rails).to receive(:env).and_return(ActiveSupport::StringInquirer.new("development"))
+        ENV["MIGRATION_GUARD_SANDBOX_QUIET"] = "false"
+
+        expect(migration_instance.send(:should_display_sandbox_messages?)).to be true
 
         ENV.delete("MIGRATION_GUARD_SANDBOX_QUIET")
       end
@@ -54,11 +97,13 @@ RSpec.describe MigrationGuard::MigrationExtension, "sandbox visual feedback" do
         expect(migration_instance.send(:should_display_sandbox_messages?)).to be false
       end
 
-      it "returns true in test environment with verbose flag" do
+      it "returns true in test environment with various verbose flag values" do
         allow(Rails).to receive(:env).and_return(ActiveSupport::StringInquirer.new("test"))
-        ENV["MIGRATION_GUARD_SANDBOX_VERBOSE"] = "true"
-
-        expect(migration_instance.send(:should_display_sandbox_messages?)).to be true
+        
+        %w[true TRUE 1 yes YES].each do |value|
+          ENV["MIGRATION_GUARD_SANDBOX_VERBOSE"] = value
+          expect(migration_instance.send(:should_display_sandbox_messages?)).to be true
+        end
 
         ENV.delete("MIGRATION_GUARD_SANDBOX_VERBOSE")
       end
@@ -69,16 +114,56 @@ RSpec.describe MigrationGuard::MigrationExtension, "sandbox visual feedback" do
         allow(Rails).to receive(:env).and_return(ActiveSupport::StringInquirer.new("development"))
       end
 
-      it "displays start message when conditions are met" do
-        expect { migration_instance.send(:display_sandbox_start_message) }
-          .to output(/🧪 SANDBOX MODE ACTIVE - Database changes will be rolled back/)
-          .to_stdout
+      context "with Rails logger available" do
+        let(:logger) { instance_double(Logger) }
+
+        before do
+          allow(Rails).to receive(:logger).and_return(logger)
+        end
+
+        it "uses Rails logger for start message" do
+          expect(logger).to receive(:info).with(match(/🧪 SANDBOX MODE ACTIVE/))
+          migration_instance.send(:display_sandbox_start_message)
+        end
+
+        it "uses Rails logger for complete message" do
+          expect(logger).to receive(:warn).with(match(/⚠️  SANDBOX: Database changes rolled back/))
+          migration_instance.send(:display_sandbox_complete_message)
+        end
       end
 
-      it "displays complete message when conditions are met" do
-        expect { migration_instance.send(:display_sandbox_complete_message) }
-          .to output(/⚠️  SANDBOX: Database changes rolled back. Schema.rb updated for inspection./)
-          .to_stdout
+      context "without Rails logger" do
+        before do
+          allow(Rails).to receive(:logger).and_return(nil)
+        end
+
+        it "displays start message to stdout when conditions are met" do
+          expect { migration_instance.send(:display_sandbox_start_message) }
+            .to output(/🧪 SANDBOX MODE ACTIVE - Database changes will be rolled back/)
+            .to_stdout
+        end
+
+        it "displays complete message to stdout when conditions are met" do
+          expect { migration_instance.send(:display_sandbox_complete_message) }
+            .to output(/⚠️  SANDBOX: Database changes rolled back. Schema.rb updated for inspection./)
+            .to_stdout
+        end
+      end
+
+      context "when messages should not be displayed" do
+        before do
+          allow(migration_instance).to receive(:should_display_sandbox_messages?).and_return(false)
+        end
+
+        it "does not display start message" do
+          expect { migration_instance.send(:display_sandbox_start_message) }
+            .not_to output.to_stdout
+        end
+
+        it "does not display complete message" do
+          expect { migration_instance.send(:display_sandbox_complete_message) }
+            .not_to output.to_stdout
+        end
       end
     end
   end

--- a/spec/lib/migration_guard/sandbox_visual_feedback_spec.rb
+++ b/spec/lib/migration_guard/sandbox_visual_feedback_spec.rb
@@ -1,0 +1,85 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+require_relative "../../../lib/migration_guard/migration_extension"
+
+# rubocop:disable RSpec/SpecFilePathFormat, RSpec/DescribeMethod
+RSpec.describe MigrationGuard::MigrationExtension, "sandbox visual feedback" do
+  # rubocop:enable RSpec/SpecFilePathFormat, RSpec/DescribeMethod
+  let(:test_migration_class) do
+    Class.new(ActiveRecord::Migration[7.0]) do
+      include MigrationGuard::MigrationExtension
+
+      def self.version
+        "20240617123456"
+      end
+
+      def up
+        # Empty migration for testing
+      end
+    end
+  end
+
+  let(:migration_instance) { test_migration_class.new }
+
+  before do
+    allow(MigrationGuard).to receive(:enabled?).and_return(true)
+
+    # Mock the connection and transaction behavior
+    connection = instance_double(ActiveRecord::ConnectionAdapters::AbstractAdapter)
+    allow(migration_instance).to receive(:connection).and_return(connection)
+    allow(connection).to receive(:transaction).and_yield
+  end
+
+  describe "sandbox mode helper methods" do
+    context "when testing should_display_sandbox_messages?" do
+      it "returns true in development environment" do
+        allow(Rails).to receive(:env).and_return(ActiveSupport::StringInquirer.new("development"))
+
+        expect(migration_instance.send(:should_display_sandbox_messages?)).to be true
+      end
+
+      it "returns false when MIGRATION_GUARD_SANDBOX_QUIET is set" do
+        allow(Rails).to receive(:env).and_return(ActiveSupport::StringInquirer.new("development"))
+        ENV["MIGRATION_GUARD_SANDBOX_QUIET"] = "true"
+
+        expect(migration_instance.send(:should_display_sandbox_messages?)).to be false
+
+        ENV.delete("MIGRATION_GUARD_SANDBOX_QUIET")
+      end
+
+      it "returns false in test environment without verbose flag" do
+        allow(Rails).to receive(:env).and_return(ActiveSupport::StringInquirer.new("test"))
+
+        expect(migration_instance.send(:should_display_sandbox_messages?)).to be false
+      end
+
+      it "returns true in test environment with verbose flag" do
+        allow(Rails).to receive(:env).and_return(ActiveSupport::StringInquirer.new("test"))
+        ENV["MIGRATION_GUARD_SANDBOX_VERBOSE"] = "true"
+
+        expect(migration_instance.send(:should_display_sandbox_messages?)).to be true
+
+        ENV.delete("MIGRATION_GUARD_SANDBOX_VERBOSE")
+      end
+    end
+
+    context "when testing display methods" do
+      before do
+        allow(Rails).to receive(:env).and_return(ActiveSupport::StringInquirer.new("development"))
+      end
+
+      it "displays start message when conditions are met" do
+        expect { migration_instance.send(:display_sandbox_start_message) }
+          .to output(/🧪 SANDBOX MODE ACTIVE - Database changes will be rolled back/)
+          .to_stdout
+      end
+
+      it "displays complete message when conditions are met" do
+        expect { migration_instance.send(:display_sandbox_complete_message) }
+          .to output(/⚠️  SANDBOX: Database changes rolled back. Schema.rb updated for inspection./)
+          .to_stdout
+      end
+    end
+  end
+end

--- a/spec/lib/migration_guard/sandbox_visual_feedback_spec.rb
+++ b/spec/lib/migration_guard/sandbox_visual_feedback_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe MigrationGuard::MigrationExtension, "sandbox visual feedback" do
                         else
                           5.2
                         end
-    
+
     Class.new(ActiveRecord::Migration[migration_version]) do
       include MigrationGuard::MigrationExtension
 
@@ -28,20 +28,20 @@ RSpec.describe MigrationGuard::MigrationExtension, "sandbox visual feedback" do
       def up
         # Empty migration for testing
       end
-      
+
       # Expose private methods for testing
       def test_env_var_truthy?(env_var_name)
         env_var_truthy?(env_var_name)
       end
-      
+
       def test_should_display_sandbox_messages?
         should_display_sandbox_messages?
       end
-      
+
       def test_display_sandbox_start_message
         display_sandbox_start_message
       end
-      
+
       def test_display_sandbox_complete_message
         display_sandbox_complete_message
       end
@@ -61,8 +61,12 @@ RSpec.describe MigrationGuard::MigrationExtension, "sandbox visual feedback" do
 
   describe "sandbox mode constants" do
     it "has defined sandbox message constants" do
-      expect(MigrationGuard::SandboxMessages::START).to eq("🧪 SANDBOX MODE ACTIVE - Database changes will be rolled back")
-      expect(MigrationGuard::SandboxMessages::COMPLETE).to eq("⚠️  SANDBOX: Database changes rolled back. Schema.rb updated for inspection.")
+      expect(MigrationGuard::SandboxMessages::START).to eq(
+        "🧪 SANDBOX MODE ACTIVE - Database changes will be rolled back"
+      )
+      expect(MigrationGuard::SandboxMessages::COMPLETE).to eq(
+        "⚠️  SANDBOX: Database changes rolled back. Schema.rb updated for inspection."
+      )
     end
   end
 
@@ -101,7 +105,7 @@ RSpec.describe MigrationGuard::MigrationExtension, "sandbox visual feedback" do
 
       it "returns false when MIGRATION_GUARD_SANDBOX_QUIET is set to various truthy values" do
         allow(Rails).to receive(:env).and_return(ActiveSupport::StringInquirer.new("development"))
-        
+
         %w[true TRUE 1 yes YES].each do |value|
           ENV["MIGRATION_GUARD_SANDBOX_QUIET"] = value
           expect(migration_instance.test_should_display_sandbox_messages?).to be false
@@ -127,7 +131,7 @@ RSpec.describe MigrationGuard::MigrationExtension, "sandbox visual feedback" do
 
       it "returns true in test environment with various verbose flag values" do
         allow(Rails).to receive(:env).and_return(ActiveSupport::StringInquirer.new("test"))
-        
+
         %w[true TRUE 1 yes YES].each do |value|
           ENV["MIGRATION_GUARD_SANDBOX_VERBOSE"] = value
           expect(migration_instance.test_should_display_sandbox_messages?).to be true

--- a/spec/lib/migration_guard/sandbox_visual_feedback_spec.rb
+++ b/spec/lib/migration_guard/sandbox_visual_feedback_spec.rb
@@ -7,7 +7,18 @@ require_relative "../../../lib/migration_guard/migration_extension"
 RSpec.describe MigrationGuard::MigrationExtension, "sandbox visual feedback" do
   # rubocop:enable RSpec/SpecFilePathFormat, RSpec/DescribeMethod
   let(:test_migration_class) do
-    Class.new(ActiveRecord::Migration[7.0]) do
+    # Use the highest supported migration version for the current Rails version
+    migration_version = if Rails.version >= "7.0"
+                          7.0
+                        elsif Rails.version >= "6.1"
+                          6.1
+                        elsif Rails.version >= "6.0"
+                          6.0
+                        else
+                          5.2
+                        end
+    
+    Class.new(ActiveRecord::Migration[migration_version]) do
       include MigrationGuard::MigrationExtension
 
       def self.version


### PR DESCRIPTION
## Summary
Adds comprehensive visual feedback for sandbox mode to improve user experience and prevent confusion.

### Key Features
- **Prominent notifications** during migration execution:
  - Shows "🧪 SANDBOX MODE ACTIVE" before migration starts
  - Shows completion message after rollback with explanation
- **Enhanced diagnostic commands**:
  - Added sandbox mode status to `rails db:migration:doctor`
  - Added sandbox mode indicator to `rails db:migration:status`
- **Configurable behavior** via environment variables:
  - `MIGRATION_GUARD_SANDBOX_QUIET=true` - Disable all sandbox feedback
  - `MIGRATION_GUARD_SANDBOX_VERBOSE=true` - Enable feedback in test environment

### Problem Solved
Resolves issue #91 where users were confused by sandbox mode behavior:
- No indication that sandbox mode was active
- Schema.rb would be updated but database changes were rolled back
- Silent operation made it unclear if sandbox mode was working

### Test Coverage
- Comprehensive test suite for all sandbox feedback scenarios
- Tests for environment variable controls
- Tests for status integration in doctor and reporter commands
- All existing tests still pass

### Example Output

**During Migration:**
```
🧪 SANDBOX MODE ACTIVE - Database changes will be rolled back
== 20240617123456 CreateUsers: migrating =====================================
-- create_table(:users)
== 20240617123456 CreateUsers: migrated (0.0010s) ============================
⚠️  SANDBOX: Database changes rolled back. Schema.rb updated for inspection.
```

**In Status Report:**
```
═══════════════════════════════════════════════════════
Migration Status (main branch)
🧪 SANDBOX MODE ACTIVE - Changes will be rolled back
═══════════════════════════════════════════════════════
```

**In Doctor Command:**
```
⚠ Sandbox mode: ACTIVE (changes will be rolled back)
```

🤖 Generated with [Claude Code](https://claude.ai/code)