### PR TITLE
fix: register git hooks generator in railtie

### DIFF
--- a/lib/migration_guard/railtie.rb
+++ b/lib/migration_guard/railtie.rb
@@ -15,6 +15,7 @@ module MigrationGuard
     # Load generators
     generators do
       require_relative "../generators/migration_guard/install/install_generator"
+      require_relative "../generators/migration_guard/hooks/hooks_generator"
     end
 
     # Initialize MigrationGuard after Rails has loaded

--- a/spec/generators/hooks_availability_spec.rb
+++ b/spec/generators/hooks_availability_spec.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+require "generators/migration_guard/hooks/hooks_generator"
+
+RSpec.describe MigrationGuard::Generators::HooksGenerator do
+  it "loads the hooks generator" do
+    expect(defined?(described_class)).to be_truthy
+  end
+
+  it "inherits from Rails::Generators::Base" do
+    expect(described_class.superclass).to eq(Rails::Generators::Base)
+  end
+
+  it "has proper description" do
+    expect(described_class.desc).to eq("Installs git hooks for Rails Migration Guard")
+  end
+end


### PR DESCRIPTION
## Summary
- Fixes issue #100 where git hooks generator wasn't available as `rails generate migration_guard:hooks`
- Adds hooks generator to railtie generators block alongside install generator
- Now properly registered and accessible in Rails applications

## Problem
The hooks generator existed but wasn't being loaded by the railtie, so it wasn't available through the standard Rails generator interface.

## Solution
Added `require_relative "../generators/migration_guard/hooks/hooks_generator"` to the generators block in railtie.rb

## Test Plan
- [x] Added test to verify generator is loaded and available
- [x] Verified generator inherits from Rails::Generators::Base
- [x] Confirmed generator has proper description
- [x] All existing tests pass

## QA Steps
1. Install gem in a Rails app
2. Run `rails generate migration_guard:hooks`
3. Verify post-checkout hook is created
4. Run `rails generate migration_guard:hooks --pre-push`
5. Verify both hooks are created

Fixes #100

🤖 Generated with [Claude Code](https://claude.ai/code)