### PR TITLE
Fix git hooks generator template path error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- **Git Hooks Generator** (#135) - Fixed template path error when backing up existing hooks:
+  - Replaced Rails' `copy_file` method with `FileUtils.cp` for file system operations
+  - Added proper tests for backup functionality
+  - Generator now correctly handles existing git hooks
+
 ### Added
 - **Interactive Setup Assistant for New Developers** (#22) - Comprehensive onboarding experience:
   - New `rails db:migration:setup` command for development environment analysis

--- a/lib/generators/migration_guard/hooks/hooks_generator.rb
+++ b/lib/generators/migration_guard/hooks/hooks_generator.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require "rails/generators"
+require "fileutils"
 
 module MigrationGuard
   module Generators
@@ -65,7 +66,7 @@ module MigrationGuard
           end
 
           backup_path = "#{hook_path}.backup"
-          copy_file hook_path, backup_path
+          FileUtils.cp(hook_path, backup_path)
           say "Backed up existing #{name} hook to #{backup_path}", :yellow
         end
 

--- a/spec/generators/migration_guard/hooks_generator_backup_spec.rb
+++ b/spec/generators/migration_guard/hooks_generator_backup_spec.rb
@@ -5,7 +5,7 @@ require "generators/migration_guard/hooks/hooks_generator"
 require "fileutils"
 require "tmpdir"
 
-RSpec.describe "MigrationGuard::Generators::HooksGenerator backup functionality" do
+RSpec.describe MigrationGuard::Generators::HooksGenerator do
   let(:destination_root) { Dir.mktmpdir }
 
   around do |example|
@@ -22,80 +22,82 @@ RSpec.describe "MigrationGuard::Generators::HooksGenerator backup functionality"
     FileUtils.remove_entry(destination_root)
   end
 
-  describe "backup creation" do
-    let(:existing_hook_content) { "#!/bin/sh\n# Custom hook\necho 'custom hook'" }
-    let(:hook_path) { ".git/hooks/post-checkout" }
-    let(:backup_path) { ".git/hooks/post-checkout.backup" }
+  describe "backup functionality" do
+    describe "backup creation" do
+      let(:existing_hook_content) { "#!/bin/sh\n# Custom hook\necho 'custom hook'" }
+      let(:hook_path) { ".git/hooks/post-checkout" }
+      let(:backup_path) { ".git/hooks/post-checkout.backup" }
 
-    before do
-      File.write(hook_path, existing_hook_content)
-      File.chmod(0o755, hook_path)
-    end
+      before do
+        File.write(hook_path, existing_hook_content)
+        File.chmod(0o755, hook_path)
+      end
 
-    it "creates a backup of existing hook" do
-      generator = MigrationGuard::Generators::HooksGenerator.new
-      
-      # Silence output for cleaner test
-      allow(generator).to receive(:say)
-      allow(generator).to receive(:say_status)
-      
-      generator.send(:create_git_hook, "post-checkout", "new content")
-      
-      expect(File.exist?(backup_path)).to be true
-      expect(File.read(backup_path)).to eq(existing_hook_content)
-    end
+      it "creates a backup of existing hook" do
+        generator = described_class.new
 
-    it "preserves file permissions in backup" do
-      generator = MigrationGuard::Generators::HooksGenerator.new
-      
-      # Silence output
-      allow(generator).to receive(:say)
-      allow(generator).to receive(:say_status)
-      
-      generator.send(:create_git_hook, "post-checkout", "new content")
-      
-      backup_stat = File.stat(backup_path)
-      
-      # Check that backup has same permissions as original had
-      expect(backup_stat.mode & 0o777).to eq(0o755)
-    end
+        # Silence output for cleaner test
+        allow(generator).to receive(:say)
+        allow(generator).to receive(:say_status)
 
-    it "overwrites existing backup if present" do
-      # Create an old backup
-      old_backup_content = "#!/bin/sh\n# Old backup"
-      File.write(backup_path, old_backup_content)
-      
-      generator = MigrationGuard::Generators::HooksGenerator.new
-      
-      # Silence output
-      allow(generator).to receive(:say)
-      allow(generator).to receive(:say_status)
-      
-      generator.send(:create_git_hook, "post-checkout", "new content")
-      
-      # Backup should contain the current hook content, not the old backup
-      expect(File.read(backup_path)).to eq(existing_hook_content)
-      expect(File.read(backup_path)).not_to eq(old_backup_content)
-    end
-  end
-
-  describe "error handling during backup" do
-    it "handles read-only hooks directory gracefully" do
-      hook_path = ".git/hooks/post-checkout"
-      File.write(hook_path, "existing content")
-      
-      # Make hooks directory read-only
-      File.chmod(0o555, ".git/hooks")
-      
-      generator = MigrationGuard::Generators::HooksGenerator.new
-      
-      # Should raise an error when trying to create backup
-      expect {
         generator.send(:create_git_hook, "post-checkout", "new content")
-      }.to raise_error(Errno::EACCES)
-      
-      # Restore permissions for cleanup
-      File.chmod(0o755, ".git/hooks")
+
+        expect(File.exist?(backup_path)).to be true
+        expect(File.read(backup_path)).to eq(existing_hook_content)
+      end
+
+      it "preserves file permissions in backup" do
+        generator = described_class.new
+
+        # Silence output
+        allow(generator).to receive(:say)
+        allow(generator).to receive(:say_status)
+
+        generator.send(:create_git_hook, "post-checkout", "new content")
+
+        backup_stat = File.stat(backup_path)
+
+        # Check that backup has same permissions as original had
+        expect(backup_stat.mode & 0o777).to eq(0o755)
+      end
+
+      it "overwrites existing backup if present" do
+        # Create an old backup
+        old_backup_content = "#!/bin/sh\n# Old backup"
+        File.write(backup_path, old_backup_content)
+
+        generator = described_class.new
+
+        # Silence output
+        allow(generator).to receive(:say)
+        allow(generator).to receive(:say_status)
+
+        generator.send(:create_git_hook, "post-checkout", "new content")
+
+        # Backup should contain the current hook content, not the old backup
+        expect(File.read(backup_path)).to eq(existing_hook_content)
+        expect(File.read(backup_path)).not_to eq(old_backup_content)
+      end
+    end
+
+    describe "error handling during backup" do
+      it "handles read-only hooks directory gracefully" do
+        hook_path = ".git/hooks/post-checkout"
+        File.write(hook_path, "existing content")
+
+        # Make hooks directory read-only
+        File.chmod(0o555, ".git/hooks")
+
+        generator = described_class.new
+
+        # Should raise an error when trying to create backup
+        expect do
+          generator.send(:create_git_hook, "post-checkout", "new content")
+        end.to raise_error(Errno::EACCES)
+
+        # Restore permissions for cleanup
+        File.chmod(0o755, ".git/hooks")
+      end
     end
   end
 end

--- a/spec/generators/migration_guard/hooks_generator_backup_spec.rb
+++ b/spec/generators/migration_guard/hooks_generator_backup_spec.rb
@@ -1,0 +1,101 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+require "generators/migration_guard/hooks/hooks_generator"
+require "fileutils"
+require "tmpdir"
+
+RSpec.describe "MigrationGuard::Generators::HooksGenerator backup functionality" do
+  let(:destination_root) { Dir.mktmpdir }
+
+  around do |example|
+    Dir.chdir(destination_root) do
+      example.run
+    end
+  end
+
+  before do
+    FileUtils.mkdir_p(".git/hooks")
+  end
+
+  after do
+    FileUtils.remove_entry(destination_root)
+  end
+
+  describe "backup creation" do
+    let(:existing_hook_content) { "#!/bin/sh\n# Custom hook\necho 'custom hook'" }
+    let(:hook_path) { ".git/hooks/post-checkout" }
+    let(:backup_path) { ".git/hooks/post-checkout.backup" }
+
+    before do
+      File.write(hook_path, existing_hook_content)
+      File.chmod(0o755, hook_path)
+    end
+
+    it "creates a backup of existing hook" do
+      generator = MigrationGuard::Generators::HooksGenerator.new
+      
+      # Silence output for cleaner test
+      allow(generator).to receive(:say)
+      allow(generator).to receive(:say_status)
+      
+      generator.send(:create_git_hook, "post-checkout", "new content")
+      
+      expect(File.exist?(backup_path)).to be true
+      expect(File.read(backup_path)).to eq(existing_hook_content)
+    end
+
+    it "preserves file permissions in backup" do
+      generator = MigrationGuard::Generators::HooksGenerator.new
+      
+      # Silence output
+      allow(generator).to receive(:say)
+      allow(generator).to receive(:say_status)
+      
+      generator.send(:create_git_hook, "post-checkout", "new content")
+      
+      backup_stat = File.stat(backup_path)
+      
+      # Check that backup has same permissions as original had
+      expect(backup_stat.mode & 0o777).to eq(0o755)
+    end
+
+    it "overwrites existing backup if present" do
+      # Create an old backup
+      old_backup_content = "#!/bin/sh\n# Old backup"
+      File.write(backup_path, old_backup_content)
+      
+      generator = MigrationGuard::Generators::HooksGenerator.new
+      
+      # Silence output
+      allow(generator).to receive(:say)
+      allow(generator).to receive(:say_status)
+      
+      generator.send(:create_git_hook, "post-checkout", "new content")
+      
+      # Backup should contain the current hook content, not the old backup
+      expect(File.read(backup_path)).to eq(existing_hook_content)
+      expect(File.read(backup_path)).not_to eq(old_backup_content)
+    end
+  end
+
+  describe "error handling during backup" do
+    it "handles read-only hooks directory gracefully" do
+      hook_path = ".git/hooks/post-checkout"
+      File.write(hook_path, "existing content")
+      
+      # Make hooks directory read-only
+      File.chmod(0o555, ".git/hooks")
+      
+      generator = MigrationGuard::Generators::HooksGenerator.new
+      
+      # Should raise an error when trying to create backup
+      expect {
+        generator.send(:create_git_hook, "post-checkout", "new content")
+      }.to raise_error(Errno::EACCES)
+      
+      # Restore permissions for cleanup
+      File.chmod(0o755, ".git/hooks")
+    end
+  end
+end


### PR DESCRIPTION
## Summary
- Fixes issue #135 where the git hooks generator fails with a template path error
- Replaces Rails' `copy_file` method with `FileUtils.cp` for backing up existing hook files
- Adds comprehensive tests for the backup functionality

## Problem
The generator was using `copy_file hook_path, backup_path` which is designed for copying template files from the generator's source directory, not for copying arbitrary files from the filesystem. This caused the error:
```
Could not find '.git/hooks/post-checkout' in any of your source paths.
```

## Solution
- Use `FileUtils.cp` instead of `copy_file` for file system operations
- Add `require "fileutils"` to ensure the module is available
- Add tests to verify backup functionality works correctly

## Test Plan
- [x] Added comprehensive tests for backup functionality
- [x] All tests pass
- [x] RuboCop checks pass
- [x] Manually tested generator creates backups correctly

Fixes #135